### PR TITLE
feat(i18n): Implement robust i18n routing for articles

### DIFF
--- a/app/[lang]/[slug]/page.tsx
+++ b/app/[lang]/[slug]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link"; // 导入 Next.js 的 Link 组件，用于客户�
 import { ArrowLeftIcon } from "@heroicons/react/24/solid"; // 从 Heroicons 图标库导入左箭头图标。
 import { getArticleData } from "@/lib/articles"; // 导入用于获取单篇文章数据的函数。
 import { getDictionary } from "@/lib/dictionaries"; // 导入用于获取字典数据的函数。
+import LanguageSwitcher from "@/components/LanguageSwitcher"; // 导入语言切换组件
 
 /**
  * Article 页面是一个动态路由页面，用于显示单篇文章的内容。
@@ -17,31 +18,36 @@ const Article = async ({ params }: { params: Promise<{ slug: string, lang: strin
     const dict = getDictionary(lang);
 
     return (
-        <section className="mx-auto w-11/12 md:w-[45rem] mt-20 flex flex-col gap-5">
-            {/* 页面顶部导航区，包含返回链接和文章日期 */}
-            <div className="flex justify-between font-poppins mb-8">
-                <Link href={`/${lang}`} className="flex flex-row gap-2 place-items-center text-gray-600 hover:text-[#3d7fdc] transition-colors">
-                    <ArrowLeftIcon width={20} />
-                    <p>{dict.back_to_home}</p>
-                </Link>
-                <p className="text-gray-500">{articleData.date.toString()}</p>
+        <>
+            <div className="w-11/12 md:w-1/2 mx-auto my-4 flex justify-end">
+                <LanguageSwitcher translations={articleData.translations} />
             </div>
+            <section className="mx-auto w-11/12 md:w-[45rem] mt-20 flex flex-col gap-5">
+                {/* 页面顶部导航区，包含返回链接和文章日期 */}
+                <div className="flex justify-between font-poppins mb-8">
+                    <Link href={`/${lang}`} className="flex flex-row gap-2 place-items-center text-gray-600 hover:text-[#3d7fdc] transition-colors">
+                        <ArrowLeftIcon width={20} />
+                        <p>{dict.back_to_home}</p>
+                    </Link>
+                    <p className="text-gray-500">{articleData.date.toString()}</p>
+                </div>
 
-            {/* 文章主标题。 */}
-            <h1 className="font-cormorantGaramond text-6xl font-light mb-8 text-neutral-900">
-                {articleData.title}
-            </h1>
+                {/* 文章主标题。 */}
+                <h1 className="font-cormorantGaramond text-6xl font-light mb-8 text-neutral-900">
+                    {articleData.title}
+                </h1>
 
-            {/*
-       * 文章正文容器。
-       * 使用 dangerouslySetInnerHTML 是因为文章内容是从 Markdown 转换来的 HTML 字符串。
-       * 在此项目中，内容源于本地文件，是可信的，因此可以安全使用。
-       */}
-            <article
-                className="article"
-                dangerouslySetInnerHTML={{ __html: articleData.contentHtml }}
-            />
-        </section>
+                {/*
+        * 文章正文容器。
+        * 使用 dangerouslySetInnerHTML 是因为文章内容是从 Markdown 转换来的 HTML 字符串。
+        * 在此项目中，内容源于本地文件，是可信的，因此可以安全使用。
+        */}
+                <article
+                    className="article"
+                    dangerouslySetInnerHTML={{ __html: articleData.contentHtml }}
+                />
+            </section>
+        </>
     );
 };
 

--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next"; // 导入 Next.js 的元数据类型，用于 SEO。
 import { Cormorant_Garamond, Poppins, Noto_Sans_SC, Noto_Serif_SC, Lora } from "next/font/google"; // 导入字体，以优化性能并避免布局偏移。
 import "./globals.css"; // 导入全局样式。
-import LanguageSwitcher from "@/components/LanguageSwitcher";
 
 const cormorantGaramond = Cormorant_Garamond({
   subsets: ["latin"],
@@ -58,9 +57,6 @@ export default function RootLayout({
         className={`${cormorantGaramond.variable} ${poppins.variable} ${notoSansSC.variable} ${notoSerifSC.variable} ${lora.variable}`} // 将字体变量作为 className 应用，使其在 CSS 中可用。
         suppressHydrationWarning={true} // 压制 hydration 警告，这通常用于处理服务器与客户端渲染的微小差异。
       >
-        <div className="w-11/12 md:w-1/2 mx-auto my-4 flex justify-end">
-          <LanguageSwitcher />
-        </div>
         <main>
           {children}
         </main>

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -1,5 +1,6 @@
 import ArticleItemList from "@/components/ArticleListItem"; // 导入文章列表组件，用于展示单个分类下的文章。
 import { getCategorizedArticles } from "@/lib/articles"; // 导入数据处理函数，用于获取并分类所有文章。
+import LanguageSwitcher from "@/components/LanguageSwitcher";
 
 /**
  * HomePage 是博客的主页。
@@ -10,29 +11,35 @@ const HomePage = async ({ params }: { params: Promise<{ lang: string }> }) => {
   const articles = getCategorizedArticles(lang); // 调用函数，获取按分类组织好的文章数据。
 
   return (
-    <section className="mx-auto w-11/12 md:w-1/2 mt-20 flex flex-col gap-16 mb-20">
-      {/* 博客标题区域，使用 Tailwind CSS 工具类来定义字体、大小、字重和边距。 */}
-      <header className="font-cormorantGaramond text-neutral-900 text-center">
-        <h1 className="text-[100px]" style={{ fontFamily: 'Cormorant Garamond, serif', fontWeight: 300 }}>
-          Aki&apos;s Blog
-        </h1>
-      </header>
+    <>
+      <div className="w-11/12 md:w-1/2 mx-auto my-4 flex justify-end">
+        <LanguageSwitcher />
+      </div>
+      
+      <section className="mx-auto w-11/12 md:w-1/2 mt-20 flex flex-col gap-16 mb-20">
+        {/* 博客标题区域，使用 Tailwind CSS 工具类来定义字体、大小、字重和边距。 */}
+        <header className="font-cormorantGaramond text-neutral-900 text-center">
+          <h1 className="text-[100px]" style={{ fontFamily: 'Cormorant Garamond, serif', fontWeight: 300 }}>
+            Aki&apos;s Blog
+          </h1>
+        </header>
 
-      {/* 文章列表区域，在桌面端为两栏网格布局。 */}
-      <section className="md:grid md:grid-cols-2 flex flex-col gap-10">
-        {/* 确保 articles 对象存在后，遍历其中的每个分类名。 */}
-        {articles !== null &&
-          Object.keys(articles).map((categoryName) => (
-            // 为每个分类渲染一个 ArticleItemList 组件。
-            <ArticleItemList
-              category={categoryName} // category: 传入当前分类的名称。
-              articles={articles[categoryName]} // articles: 传入该分类下的文章数组。
-              lang={lang} // lang: 传入当前语言。
-              key={categoryName} // key: 使用分类名作为 React 列表渲染的唯一标识。
-            />
-          ))}
+        {/* 文章列表区域，在桌面端为两栏网格布局。 */}
+        <section className="md:grid md:grid-cols-2 flex flex-col gap-10">
+          {/* 确保 articles 对象存在后，遍历其中的每个分类名。 */}
+          {articles !== null &&
+            Object.keys(articles).map((categoryName) => (
+              // 为每个分类渲染一个 ArticleItemList 组件。
+              <ArticleItemList
+                category={categoryName} // category: 传入当前分类的名称。
+                articles={articles[categoryName]} // articles: 传入该分类下的文章数组。
+                lang={lang} // lang: 传入当前语言。
+                key={categoryName} // key: 使用分类名作为 React 列表渲染的唯一标识。
+              />
+            ))}
+        </section>
       </section>
-    </section>
+    </>
   );
 };
 

--- a/articles/en/derrida-what-is-poetry.md
+++ b/articles/en/derrida-what-is-poetry.md
@@ -2,6 +2,7 @@
 title: "Derrida: What is Poetry?"
 category: "note"
 date: "2025-01-14"
+translationId: "derrida-poetry"
 ---
 
 [Derrida: What is Poetry?](https://ptext.nju.edu.cn/c4/82/c12242a246914/page.htm)

--- a/articles/zh/德里达：什么是诗.md
+++ b/articles/zh/德里达：什么是诗.md
@@ -2,6 +2,7 @@
 title: "德里达: 什么是诗？"
 category: "笔记"
 date: "2025-01-14"
+translationId: "derrida-poetry"
 ---
 
 [德里达：什么是诗？](https://ptext.nju.edu.cn/c4/82/c12242a246914/page.htm)

--- a/components/ArticleListItem.tsx
+++ b/components/ArticleListItem.tsx
@@ -31,7 +31,7 @@ const ArticleItemList = ({ category, articles, lang }: Props) => {
                     <Link
                         href={`/${lang}/${article.id}`} // 指向文章详情页的动态路由。
                         key={article.id} // React 列表渲染优化所需的 key。
-                        className="font-cormorantGaramond text-xl text-black hover:text-[#3d7fdc]" // 文章链接的样式和悬停效果。
+                        className="font-cormorantGaramond text-xl font-medium text-black hover:text-[#3d7fdc]" // 文章链接的样式和悬停效果。
                     >
                         {article.title}
                     </Link>

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -2,25 +2,63 @@
 
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
+import { Fragment } from 'react';
 
-const LanguageSwitcher = () => {
+// 定义组件的 props 类型
+interface Props {
+    translations?: Record<string, string>;
+}
+
+// 定义支持的语言列表
+const supportedLanguages = [
+    { code: 'en', name: 'English' },
+    { code: 'zh', name: '中文' },
+    { code: 'ja', name: '日本語' },
+];
+
+const LanguageSwitcher = ({ translations }: Props) => {
     const pathname = usePathname();
 
     // 根据当前路径生成切换语言后的新路径
-    const getLinkForLang = (lang: string) => {
+    const getLinkForLangDefault = (lang: string) => {
         if (!pathname) return '/';
         const segments = pathname.split('/');
-        segments[1] = lang; // URL 的第二部分 ([lang]) 会被替换为新的语言代码
+        segments[1] = lang; // 替换 URL 的第二部分 ([lang]) 为新的语言代码
         return segments.join('/');
     };
 
     return (
-        <div className="flex gap-3 text-sm font-poppins text-gray-500">
-            <Link href={getLinkForLang('en')} className="hover:text-[#3d7fdc]">English</Link>
-            <span>/</span>
-            <Link href={getLinkForLang('zh')} className="hover:text-[#3d7fdc]">中文</Link>
-            <span>/</span>
-            <Link href={getLinkForLang('ja')} className="hover:text-[#3d7fdc]">日本語</Link>
+        <div className="flex gap-3 text-sm font-poppins text-gray-500 items-center">
+            {supportedLanguages.map((lang, index) => (
+                // Fragment 用于包裹每个语言链接和分隔符
+                <Fragment key={lang.code}>
+                    {translations ? (
+                        // --- 智能模式 (文章页) ---
+                        translations[lang.code] ? (
+                            // 如果该语言的翻译存在，则渲染一个可点击的 Link
+                            <Link
+                                href={`/${lang.code}/${translations[lang.code]}`}
+                                className="hover:text-[#3d7fdc] transition-colors"
+                            >
+                                {lang.name}
+                            </Link>
+                        ) : (
+                            // 如果翻译不存在，则渲染一个不可点击的、样式不同的 span
+                            <span className="text-gray-400 cursor-not-allowed">
+                                {lang.name}
+                            </span>
+                        )
+                    ) : (
+                        // --- 默认模式 (非文章页) ---
+                        <Link href={getLinkForLangDefault(lang.code)} className="hover:text-[#3d7fdc]">
+                            {lang.name}
+                        </Link>
+                    )}
+
+                    {/* 在最后一个语言链接后不显示分隔符 */}
+                    {index < supportedLanguages.length - 1 && <span>/</span>}
+                </Fragment>
+            ))}
         </div>
     );
 };

--- a/lib/articles.ts
+++ b/lib/articles.ts
@@ -5,61 +5,72 @@ import { remark } from "remark"          // 导入 remark 库，用于将 Markdo
 import moment from "moment"              // 导入 moment 库，用于日期格式化和比较
 import html from "remark-html"           // 导入 remark-html 插件，将 Markdown AST 转换为 HTML 字符串
 
-// 导入自定义的文章数据类型定义
-import type { ArticleItem } from "@/types"
+import type { ArticleItem, ArticleData } from "@/types" // 导入自定义的文章数据类型定义
+const baseArticlesDirectory = path.join(process.cwd(), "articles") // 获取 articles 文件夹的绝对路径
+const supportedLangs = ["en", "zh", "ja"] // 支持的语言列表
+let allArticlesCache: (ArticleItem & { lang: string })[] | undefined // 缓存所有文章的元数据
 
-// 获取 articles 文件夹的绝对路径
-// process.cwd() 返回当前工作目录，path.join() 将路径片段连接成完整路径
-const baseArticlesDirectory = path.join(process.cwd(), "articles")
 
 /**
- * 获取所有文章并按日期排序
+ * @returns {(ArticleItem & { lang: string })[]} 包含所有文章元数据和其所属语言的数组。
+ */
+const getAllArticles = (): (ArticleItem & { lang: string })[] => {
+    if (allArticlesCache) return allArticlesCache
+
+    const allarticles: (ArticleItem & { lang: string })[] = []
+
+    supportedLangs.forEach(lang => {
+        const langDirectory = path.join(baseArticlesDirectory, lang)
+
+        if (!fs.existsSync(langDirectory)) return
+
+        const fileNames = fs.readdirSync(langDirectory)
+
+        fileNames.forEach((fileName) => {
+            if (!fileName.endsWith(".md")) return
+
+            const id = fileName.replace(/\.md$/, "")
+            const fullPath = path.join(langDirectory, fileName)
+            const fileContents = fs.readFileSync(fullPath, "utf8")
+            const matterResult = matter(fileContents)
+
+            allarticles.push({
+                id,
+                lang,
+                title: matterResult.data.title,
+                date: matterResult.data.date,
+                category: matterResult.data.category,
+                translationId: matterResult.data.translationId,
+            })
+        })
+    })
+
+    allArticlesCache = allarticles
+    return allArticlesCache
+}
+
+
+
+/**
+ * 获取制定语言下所有文章并按日期排序
+ * @param {string} lang - 语言代码 (e.g., "zh")
  * @returns {ArticleItem[]} 排序后的文章数组
  */
 const getSortedArticles = (lang: string): ArticleItem[] => {
-    
-    const articlesDirectory = path.join(baseArticlesDirectory, lang) // 读取 articles 目录下的所有文件名
+    const allArticles = getAllArticles()
+    const articlesForLang = allArticles.filter(article => article.lang === lang)
 
-    if (!fs.existsSync(articlesDirectory)) {
-        return []
-    }
-
-    const fileNames = fs.readdirSync(articlesDirectory)
-
-    // 处理每个 .md 文件，提取文章的基本信息
-    const allArticlesData = fileNames.map((fileName) => { 
-        const id = fileName.replace(/\.md$/, "")                // 去掉文件扩展名 .md，作为文章的唯一标识符
-        const fullPath = path.join(articlesDirectory, fileName) // 构建文件的完整路径
-        const fileContents = fs.readFileSync(fullPath, "utf8")  // 读取文件内容（UTF-8 编码）
-        const matterResult = matter(fileContents) // 使用 gray-matter 解析 Markdown 文件，分离元数据和正文内容
-
-        return {
-            id,
-            title: matterResult.data.title,       // 文章标题
-            date: matterResult.data.date,         // 发布日期
-            category: matterResult.data.category, // 文章分类
-        }
-    })
-
-    // 按日期排序文章（最旧的在前）
-    return allArticlesData.sort((a, b) => {
+    return articlesForLang.sort((a, b) => {
         const format = "YYYY-MM-DD"
         const dateA = moment(a.date, format)
         const dateB = moment(b.date, format)
-
-        // 如果 A 比 B 早，返回 -1（A 排在前面）
-        if (dateA.isBefore(dateB)) {
-            return -1
-        } else if (dateB.isAfter(dateA)) {
-            return 1
-        } else {
-            return 0  // 日期相同
-        }
+        return dateA.isBefore(dateB) ? 1 : -1
     })
 }
 
 /**
  * 将文章按分类进行分组
+ * @param {string} lang 语言代码
  * @returns {Record<string, ArticleItem[]>} 以分类名为键，文章数组为值的对象
  */
 export const getCategorizedArticles = (lang: string): Record<string, ArticleItem[]> => {
@@ -68,6 +79,7 @@ export const getCategorizedArticles = (lang: string): Record<string, ArticleItem
 
     // 遍历每篇文章，按分类进行分组
     sortedArticles.forEach((article) => {
+        const category = article.category || "Uncategorized"
         if (!categorizedArticles[article.category]) {
             categorizedArticles[article.category] = [] // 如果这个分类还不存在，创建一个空数组
         }
@@ -78,28 +90,50 @@ export const getCategorizedArticles = (lang: string): Record<string, ArticleItem
 }
 
 /**
- * 获取单篇文章的完整内容（包括转换后的 HTML）
- * @param {string} id 文章的唯一标识符
+ * 获取单篇文章的完整内容（包括转换后的 HTML）,并附带所有可用翻译版本的信息。
+ * @param {string} lang 语言代码
+ * @param {string} id 文章的 slug
  * @returns {Promise} 包含文章完整信息的 Promise 对象
  */
-export const getArticleData = async (lang: string, id: string) => {
+export const getArticleData = async (lang: string, id: string): Promise<ArticleData> => {
     const fullPath = path.join(baseArticlesDirectory, lang, `${id}.md`)
     const fileContents = fs.readFileSync(fullPath, "utf-8")   // 读取文件内容
-    const matterResult = matter(fileContents)                 // 解析 Markdown 文件，分离元数据和正文
+    const matterResult = matter(fileContents) // 解析 Markdown 文件，分离元数据和正文
 
     // 使用 remark 将 Markdown 正文转换为 HTML
     const processedContent = await remark()
         .use(html)  // 使用 html 插件进行转换
         .process(matterResult.content)  // 处理正文内容
 
-    const contentHtml = processedContent.toString() // 将处理结果转换为字符串
+    const contentHtml = processedContent.toString()
 
-    // 返回文章的完整信息
+    const translationId = matterResult.data.translationId
+    const translations: Record<string, string> = {}
+
+    if (translationId) {
+        // 如果有 translationId，就从所有文章中寻找匹配项
+        const allArticles = getAllArticles()
+        const avaliableTranslations = allArticles.filter(
+            article => article.translationId === translationId
+        )
+
+        // 将所有可用翻译版本的信息添加到 translations 对象中
+        avaliableTranslations.forEach(article => {
+            translations[article.lang] = article.id
+        })
+    } else {
+        // 如果没有 translationId，则认为只有当前语言版本可用
+        translations[lang] = id
+    }
+
+    // 返回符合 ArticleData 类型的完整对象
     return {
         id,
         contentHtml,  // 转换后的 HTML 内容
         title: matterResult.data.title,
-        categoty: matterResult.data.category,
+        category: matterResult.data.category,
         date: moment(matterResult.data.date).format("YYYY-MM-DD"),  // 格式化日期
+        translationId: matterResult.data.translationId,
+        translations, // 所有可用翻译版本的信息
     }
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -3,4 +3,10 @@ export type ArticleItem = {
     title: string 
     date: string
     category: string
+    translationId: string
+}
+
+export type ArticleData = ArticleItem & {
+    contentHtml: string
+    translations: Record<string, string>; // 存储可用翻译的对象, e.g., { en: 'slug-en', zh: 'slug-zh' }
 }


### PR DESCRIPTION
- Introduce `translationId` in frontmatter to create a unique, language-agnostic link between translated articles.
- Refactor `lib/articles` to cache all article metadata, enabling efficient lookup of available translations based on `translationId`.
- Upgrade `LanguageSwitcher` component to use the new translation data, allowing it to generate direct links to translated articles or gracefully disable links for unavailable languages.
- This change fixes errors on article pages and significantly improves the multi-language user experience.