### PR TITLE
feat: 重构主页以显示分类卡片和分类统计信息

### DIFF
--- a/app/[lang]/category/[categoryName]/page.tsx
+++ b/app/[lang]/category/[categoryName]/page.tsx
@@ -1,0 +1,84 @@
+import Link from "next/link";
+import { ArrowLeftIcon } from "@heroicons/react/24/solid";
+import { getCategorizedArticles } from "@/lib/articles";
+import { getDictionary } from "@/lib/dictionaries";
+import LanguageSwitcher from "@/components/LanguageSwitcher";
+
+/**
+ * CategoryPage - 分类页面
+ * 显示指定分类下的所有文章列表
+ */
+const CategoryPage = async ({
+    params
+}: {
+    params: Promise<{ lang: string; categoryName: string }>
+}) => {
+    const { lang, categoryName } = await params;
+    const decodedCategoryName = decodeURIComponent(categoryName);
+
+    // 获取该语言下的所有分类文章
+    const categorizedArticles = getCategorizedArticles(lang);
+    const articles = categorizedArticles[decodedCategoryName] || [];
+
+    const dict = getDictionary(lang);
+
+    return (
+        <>
+            <div className="w-11/12 md:w-1/2 mx-auto my-4 flex justify-end">
+                <LanguageSwitcher />
+            </div>
+
+            <section className="mx-auto w-11/12 md:w-1/2 mt-20 flex flex-col gap-8 mb-20">
+                {/* 导航区域 */}
+                <div className="flex justify-between items-center font-poppins mb-8">
+                    <Link
+                        href={`/${lang}`}
+                        className="flex flex-row gap-2 place-items-center text-gray-600 hover:text-[#3d7fdc] transition-colors"
+                    >
+                        <ArrowLeftIcon width={20} />
+                        <p>{dict.back_to_home}</p>
+                    </Link>
+                </div>
+
+                {/* 分类标题 */}
+                <header className="mb-8">
+                    <h1 className="font-cormorantGaramond text-6xl font-light mb-4 text-neutral-900">
+                        {decodedCategoryName}
+                    </h1>
+                    <p className="font-poppins text-gray-600">
+                        {articles.length} {articles.length === 1 ? dict.article : dict.articles} {dict.articles_in_category}
+                    </p>
+                </header>
+
+                {/* 文章列表 */}
+                {articles.length > 0 ? (
+                    <section className="flex flex-col gap-6">
+                        {articles.map((article) => (
+                            <article key={article.id} className="border-b border-gray-100 pb-6 last:border-b-0">
+                                <Link
+                                    href={`/${lang}/${article.id}`}
+                                    className="group block"
+                                >
+                                    <h2 className="font-cormorantGaramond text-2xl font-medium text-black group-hover:text-[#3d7fdc] transition-colors mb-2">
+                                        {article.title}
+                                    </h2>
+                                    <p className="font-poppins text-sm text-gray-500">
+                                        {article.date}
+                                    </p>
+                                </Link>
+                            </article>
+                        ))}
+                    </section>
+                ) : (
+                    <div className="text-center py-16">
+                        <p className="font-poppins text-gray-500 text-lg">
+                            {dict.no_articles_found}
+                        </p>
+                    </div>
+                )}
+            </section>
+        </>
+    );
+};
+
+export default CategoryPage; 

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -1,14 +1,16 @@
-import ArticleItemList from "@/components/ArticleListItem"; // 导入文章列表组件，用于展示单个分类下的文章。
-import { getCategorizedArticles } from "@/lib/articles"; // 导入数据处理函数，用于获取并分类所有文章。
+import CategoryCard from "@/components/CategoryCard"; // 导入新的分类卡片组件
+import { getCategoryStats } from "@/lib/articles"; // 导入分类统计函数
+import { getDictionary } from "@/lib/dictionaries"; // 导入字典函数
 import LanguageSwitcher from "@/components/LanguageSwitcher";
 
 /**
  * HomePage 是博客的主页。
- * 它在服务端获取所有文章，按分类进行组织，并渲染出文章列表。
+ * 重构后只显示分类卡片，用户需要点击分类来查看具体文章
  */
 const HomePage = async ({ params }: { params: Promise<{ lang: string }> }) => {
   const { lang } = await params; // 在Next.js 15中，params是一个Promise，需要await
-  const articles = getCategorizedArticles(lang); // 调用函数，获取按分类组织好的文章数据。
+  const categoryStats = getCategoryStats(lang); // 获取分类统计信息
+  const dict = getDictionary(lang); // 获取多语言字典
 
   return (
     <>
@@ -16,28 +18,36 @@ const HomePage = async ({ params }: { params: Promise<{ lang: string }> }) => {
         <LanguageSwitcher />
       </div>
       
-      <section className="mx-auto w-11/12 md:w-1/2 mt-20 flex flex-col gap-16 mb-20">
-        {/* 博客标题区域，使用 Tailwind CSS 工具类来定义字体、大小、字重和边距。 */}
+      <section className="mx-auto w-11/12 md:w-2/3 lg:w-1/2 mt-20 flex flex-col gap-16 mb-20">
+        {/* 博客标题区域 */}
         <header className="font-cormorantGaramond text-neutral-900 text-center">
           <h1 className="text-[100px]" style={{ fontFamily: 'Cormorant Garamond, serif', fontWeight: 300 }}>
             Aki&apos;s Blog
           </h1>
+          <p className="font-poppins text-gray-600 text-lg mt-4">
+            {dict.explore_subtitle}
+          </p>
         </header>
 
-        {/* 文章列表区域，在桌面端为两栏网格布局。 */}
-        <section className="md:grid md:grid-cols-2 flex flex-col gap-10">
-          {/* 确保 articles 对象存在后，遍历其中的每个分类名。 */}
-          {articles !== null &&
-            Object.keys(articles).map((categoryName) => (
-              // 为每个分类渲染一个 ArticleItemList 组件。
-              <ArticleItemList
-                category={categoryName} // category: 传入当前分类的名称。
-                articles={articles[categoryName]} // articles: 传入该分类下的文章数组。
-                lang={lang} // lang: 传入当前语言。
-                key={categoryName} // key: 使用分类名作为 React 列表渲染的唯一标识。
-              />
-            ))}
+        {/* 分类卡片网格 */}
+        <section className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {categoryStats.map((category) => (
+            <CategoryCard
+              key={category.name}
+              category={category}
+              lang={lang}
+            />
+          ))}
         </section>
+
+        {/* 如果没有分类，显示提示信息 */}
+        {categoryStats.length === 0 && (
+          <div className="text-center py-16">
+            <p className="font-poppins text-gray-500 text-lg">
+              {dict.no_articles_available}
+            </p>
+          </div>
+        )}
       </section>
     </>
   );

--- a/components/CategoryCard.tsx
+++ b/components/CategoryCard.tsx
@@ -1,0 +1,56 @@
+import Link from "next/link";
+import type { CategoryStat } from "@/types";
+import { getDictionary } from "@/lib/dictionaries";
+
+interface Props {
+    category: CategoryStat;
+    lang: string;
+}
+
+/**
+ * CategoryCard - 分类卡片组件
+ * 用于在主页展示单个分类的信息，包含分类名称、文章数量和链接
+ */
+const CategoryCard = ({ category, lang }: Props) => {
+    const dict = getDictionary(lang);
+
+    return (
+        <Link
+            href={`/${lang}/category/${encodeURIComponent(category.name)}`}
+            className="group block"
+        >
+            <div className="bg-white border border-gray-100 rounded-lg p-6 hover:shadow-lg hover:border-gray-200 transition-all duration-300 ease-in-out group-hover:-translate-y-1">
+                {/* 分类名称 */}
+                <h2 className="font-cormorantGaramond text-2xl font-medium text-neutral-900 mb-3 group-hover:text-[#3d7fdc] transition-colors">
+                    {category.name}
+                </h2>
+
+                {/* 文章数量统计 */}
+                <div className="flex items-center justify-between">
+                    <p className="text-gray-500 font-poppins text-sm">
+                        {category.articleCount} {category.articleCount === 1 ? dict.article : dict.articles}
+                    </p>
+
+                    {/* 箭头图标 */}
+                    <svg
+                        className="w-5 h-5 text-gray-400 group-hover:text-[#3d7fdc] group-hover:translate-x-1 transition-all"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                    >
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
+                    </svg>
+                </div>
+
+                {/* 可选：分类描述 */}
+                {category.description && (
+                    <p className="text-gray-600 text-sm mt-3 leading-relaxed">
+                        {category.description}
+                    </p>
+                )}
+            </div>
+        </Link>
+    );
+};
+
+export default CategoryCard; 

--- a/lib/articles.ts
+++ b/lib/articles.ts
@@ -8,7 +8,7 @@ import rehypeStringify from 'rehype-stringify' // 导入 rehype-stringify 插件
 import remarkGfm from "remark-gfm"
 import remarkAddTooltipData from "./remark-add-tooltip-data.js"
 
-import type { ArticleItem, ArticleData } from "@/types" // 导入自定义的文章数据类型定义
+import type { ArticleItem, ArticleData, CategoryStat } from "@/types" // 导入自定义的文章数据类型定义
 const baseArticlesDirectory = path.join(process.cwd(), "articles") // 获取 articles 文件夹的绝对路径
 const supportedLangs = ["en", "zh", "ja"] // 支持的语言列表
 let allArticlesCache: (ArticleItem & { lang: string })[] | undefined // 缓存所有文章的元数据
@@ -142,4 +142,23 @@ export const getArticleData = async (lang: string, id: string): Promise<ArticleD
         translationId: matterResult.data.translationId,
         translations, // 所有可用翻译版本的信息
     }
+}
+
+/**
+ * 获取指定语言下所有分类的统计信息（用于主页显示）
+ * @param {string} lang 语言代码
+ * @returns {CategoryStat[]} 分类统计信息数组，按文章数量降序排列
+ */
+export const getCategoryStats = (lang: string): CategoryStat[] => {
+    const categorizedArticles = getCategorizedArticles(lang)
+
+    const categoryStats: CategoryStat[] = Object.keys(categorizedArticles).map(categoryName => ({
+        name: categoryName,
+        articleCount: categorizedArticles[categoryName].length,
+        // 可以在这里添加分类描述的逻辑
+        description: undefined
+    }))
+
+    // 按文章数量降序排列，确保内容最多的分类优先显示
+    return categoryStats.sort((a, b) => b.articleCount - a.articleCount)
 }

--- a/lib/dictionaries.ts
+++ b/lib/dictionaries.ts
@@ -1,12 +1,38 @@
-const dictionaries: Record<string, { back_to_home: string }> = {
+const dictionaries: Record<string, {
+    back_to_home: string;
+    article: string;
+    articles: string;
+    articles_in_category: string;
+    no_articles_found: string;
+    explore_subtitle: string;
+    no_articles_available: string;
+}> = {
     en: {
         back_to_home: "back to home",
+        article: "article",
+        articles: "articles",
+        articles_in_category: "in this category",
+        no_articles_found: "No articles found in this category.",
+        explore_subtitle: "Explore thoughts on philosophy, literature, and art",
+        no_articles_available: "No articles available in this language yet.",
     },
     zh: {
         back_to_home: "返回主页",
+        article: "篇文章",
+        articles: "篇文章",
+        articles_in_category: "篇文章",
+        no_articles_found: "此分类下暂无文章。",
+        explore_subtitle: "探索哲学、文学与艺术的思考",
+        no_articles_available: "此语言下暂无文章。",
     },
     ja: {
         back_to_home: "ホームページに戻る",
+        article: "記事",
+        articles: "記事",
+        articles_in_category: "件の記事",
+        no_articles_found: "このカテゴリには記事がありません。",
+        explore_subtitle: "哲学、文学、芸術についての考察を探る",
+        no_articles_available: "この言語の記事はまだありません。",
     },
 };
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -15,3 +15,10 @@ export type ArticleData = ArticleItem & {
     contentHtml: string
     translations: Record<string, string>; // 存储可用翻译的对象, e.g., { en: 'slug-en', zh: 'slug-zh' }
 }
+
+// 新增：分类统计类型，用于主页显示
+export type CategoryStat = {
+    name: string;           // 分类名称
+    articleCount: number;   // 该分类下的文章数量
+    description?: string;   // 可选的分类描述
+}


### PR DESCRIPTION
- 引入新的分类卡片组件，替换原有的文章列表展示方式。
- 添加分类统计函数以获取每个分类的文章数量，并在主页上展示。
- 更新多语言字典，支持新的分类相关文本。
- 修改类型定义，新增分类统计类型以支持分类信息的管理。